### PR TITLE
Image & video dedupe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <div align="center">
     <img src="socialserver/static/logo256.png" style="width:64px;margin-top:12px;margin-bottom:5px;"/>
-    <h1 style="margin-top:0;margin-bottom:5px;">socialserver-neo</h1>
+    <h1 style="margin-top:0;margin-bottom:5px;">socialserver</h1>
 </div>
 
-The server side of an open source social media platform. This is a rewrite of a previous implementation, that adds a new
+The server side of an open shurce social media platform. This is a rewrite of a previous implementation, that adds a new
 API, and many more features, including actually being stable (eventually), actually working properly (eventually), being
 easy to deploy and work with (eventually), and being far more maintainable.
 
@@ -31,16 +31,5 @@ The test suite is written using pytest. Just run ```pytest socialserver``` from 
 
 ### Notes
 
-- Currently, there is no stability; API version 3 has not been frozen yet, and *anything* is possible to change!
-- API version 2 does not exist
-    - If you ask where it is, or what happened to it, somebody will show up at your house within the week to have you
-      silenced.
-    - It kinda exists. APIv1 doesn't work without a few endpoints marked as APIv2. Make no mistake, these are not
-      seperate, as some APIv1 functionality utilises APIv2 features, because reasons???
-    - The current API version is always to be the same as the server major version, and due to some terrible decisions
-      in the past (see above point)
-- There is currently no setup process to create a server admin. You can use the hacky little built in user creation
-  wizard by running ```python3 -m socialserver mk-user```, to create an admin user. This will change in the future.
-  (Web based initial setup at some point.)
-- There is currently no real API documentation. If for whatever reason you want to mess with this in its current state,
-  you'll have to figure this out yourself, or email me.
+- There is no proper way to create an admin user, due to the initial setup not being done yet. For now, you can
+  run ```python3 -m socialserver mk-user```. This will allow you to create a user with the administrator attribute.

--- a/socialserver/api/v3/video.py
+++ b/socialserver/api/v3/video.py
@@ -22,7 +22,7 @@ class Video(Resource):
         if video is None:
             return {"error": ErrorCodes.OBJECT_NOT_FOUND.value}, 404
 
-        file = f"{VIDEO_DIR}/{kwargs.get('videoid')}/video.mp4"
+        file = f"{VIDEO_DIR}/{video.sha256sum}/video.mp4"
 
         return send_file(file)
 

--- a/socialserver/db.py
+++ b/socialserver/db.py
@@ -188,8 +188,13 @@ def define_entities(db_object):
     class Image(db_object.Entity):
         uploader = orm.Required("User")
         creation_time = orm.Required(datetime.datetime)
-        # uuid used to retrieve the image from storage
+        # identifier used to retrieve an image object
         identifier = orm.Required(str)
+        # sha256 hash of the image, for detecting duplicate uploads.
+        sha256_hash = orm.Required(str)
+        # identifier used to store the image on disk. can be shared if multiple users
+        # post an image with the same SHA256 hash.
+        file_identifier = orm.Required(str)
         associated_profile_pics = orm.Set("User", reverse="profile_pic")
         associated_header_pics = orm.Set("User", reverse="header_pic")
         associated_posts = orm.Set("Post", reverse="images")
@@ -201,10 +206,10 @@ def define_entities(db_object):
         @property
         def is_orphan(self):
             return (
-                len(self.associated_posts) == 0
-                and len(self.associated_profile_pics) == 0
-                and len(self.associated_header_pics)
-                and len(self.associated_thumbnails) == 0
+                    len(self.associated_posts) == 0
+                    and len(self.associated_profile_pics) == 0
+                    and len(self.associated_header_pics)
+                    and len(self.associated_thumbnails) == 0
             )
 
     class Hashtag(db_object.Entity):
@@ -259,8 +264,9 @@ def define_entities(db_object):
     class Video(db_object.Entity):
         owner = orm.Required("User")
         creation_time = orm.Required(datetime.datetime)
-        # for both video and thumbnail.
         identifier = orm.Required(str)
+        file_identifier = orm.Required(str)
+        sha256_hash = orm.Required(str)
         associated_posts = orm.Set("Post", reverse="video")
         thumbnail = orm.Required("Image", reverse="associated_thumbnails")
         # this probably won't be implemented for a while, but

--- a/socialserver/db.py
+++ b/socialserver/db.py
@@ -190,11 +190,9 @@ def define_entities(db_object):
         creation_time = orm.Required(datetime.datetime)
         # identifier used to retrieve an image object
         identifier = orm.Required(str)
-        # sha256 hash of the image, for detecting duplicate uploads.
+        # sha256 hash of the image, for detecting duplicate uploads,
+        # and for storage purposes.
         sha256sum = orm.Required(str)
-        # identifier used to store the image on disk. can be shared if multiple users
-        # post an image with the same SHA256 hash.
-        file_identifier = orm.Required(str)
         associated_profile_pics = orm.Set("User", reverse="profile_pic")
         associated_header_pics = orm.Set("User", reverse="header_pic")
         associated_posts = orm.Set("Post", reverse="images")
@@ -265,7 +263,7 @@ def define_entities(db_object):
         owner = orm.Required("User")
         creation_time = orm.Required(datetime.datetime)
         identifier = orm.Required(str)
-        file_identifier = orm.Required(str)
+        # videos are stored by their sha256sum.
         sha256sum = orm.Required(str)
         associated_posts = orm.Set("Post", reverse="video")
         thumbnail = orm.Required("Image", reverse="associated_thumbnails")

--- a/socialserver/db.py
+++ b/socialserver/db.py
@@ -191,7 +191,7 @@ def define_entities(db_object):
         # identifier used to retrieve an image object
         identifier = orm.Required(str)
         # sha256 hash of the image, for detecting duplicate uploads.
-        sha256_hash = orm.Required(str)
+        sha256sum = orm.Required(str)
         # identifier used to store the image on disk. can be shared if multiple users
         # post an image with the same SHA256 hash.
         file_identifier = orm.Required(str)
@@ -206,10 +206,10 @@ def define_entities(db_object):
         @property
         def is_orphan(self):
             return (
-                    len(self.associated_posts) == 0
-                    and len(self.associated_profile_pics) == 0
-                    and len(self.associated_header_pics)
-                    and len(self.associated_thumbnails) == 0
+                len(self.associated_posts) == 0
+                and len(self.associated_profile_pics) == 0
+                and len(self.associated_header_pics)
+                and len(self.associated_thumbnails) == 0
             )
 
     class Hashtag(db_object.Entity):
@@ -266,7 +266,7 @@ def define_entities(db_object):
         creation_time = orm.Required(datetime.datetime)
         identifier = orm.Required(str)
         file_identifier = orm.Required(str)
-        sha256_hash = orm.Required(str)
+        sha256sum = orm.Required(str)
         associated_posts = orm.Set("Post", reverse="video")
         thumbnail = orm.Required("Image", reverse="associated_thumbnails")
         # this probably won't be implemented for a while, but

--- a/socialserver/tests/api/v3/test_image.py
+++ b/socialserver/tests/api/v3/test_image.py
@@ -12,7 +12,7 @@ def test_upload_image(test_db, server_address, image_data_binary):
         files={"image": image_data_binary},
         headers={"Authorization": f"Bearer {test_db.access_token}"},
     )
-    print(r.json())
+    print(r.text)
     assert r.status_code == 201
 
 
@@ -22,6 +22,7 @@ def test_get_image(test_db, server_address, image_data_binary):
         files={"image": image_data_binary},
         headers={"Authorization": f"Bearer {test_db.access_token}"},
     ).json()["identifier"]
+    print(image_identifier)
     r = requests.get(
         f"{server_address}/api/v3/image/{image_identifier}",
         json={"wanted_type": "post", "pixel_ratio": 1},

--- a/socialserver/util/image.py
+++ b/socialserver/util/image.py
@@ -66,6 +66,9 @@ def save_images_to_disk(images: dict, image_hash: str) -> None:
             progressive=True,
         )
 
+    # FIXME: this is due to some deficiencies in the testing process.
+    if path.exists(f"{IMAGE_DIR}/{image_hash}"):
+        return
     mkdir(f"{IMAGE_DIR}/{image_hash}")
     for i in images.keys():
         if i == ImageTypes.ORIGINAL:
@@ -370,6 +373,8 @@ def process_image(image: Image, image_hash: str, image_id: int) -> None:
     db_image = db.Image.get(id=image_id)
     db_image.processed = True
     db_image.blur_hash = generate_blur_hash(image)
+
+    commit()
 
     console.log(f"Image, id={image_id}, processed.")
 

--- a/socialserver/util/image.py
+++ b/socialserver/util/image.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from base64 import b64encode
 import PIL
 from PIL import Image, ImageOps
-from pony.orm import commit, db_session
+from pony.orm import commit, db_session, select
 from socialserver.util.config import config
 from socialserver.util.output import console
 from socialserver.db import db
@@ -33,6 +33,7 @@ from typing import Tuple
 import blurhash
 from io import BytesIO
 from threading import Thread
+from hashlib import sha256
 
 IMAGE_DIR = config.media.images.storage_dir
 # where straight uploaded images are stored.
@@ -56,20 +57,20 @@ if not path.exists(IMAGE_DIR):
 
 # TODO: not sure how to best represent a dict with pythons type
 # annotations. Need to fix this.
-def save_images_to_disk(images: dict, access_id: str) -> None:
+def save_images_to_disk(images: dict, image_hash: str) -> None:
     def save_with_pixel_ratio(image, filename, pixel_ratio):
         image.save(
-            f"{IMAGE_DIR}/{access_id}/{filename}_{pixel_ratio}x.jpg",
+            f"{IMAGE_DIR}/{image_hash}/{filename}_{pixel_ratio}x.jpg",
             type="JPEG",
             quality=IMAGE_QUALITY,
             progressive=True,
         )
 
-    mkdir(f"{IMAGE_DIR}/{access_id}")
+    mkdir(f"{IMAGE_DIR}/{image_hash}")
     for i in images.keys():
         if i == ImageTypes.ORIGINAL:
             images[i][0].save(
-                f"{IMAGE_DIR}/{access_id}/{ImageTypes.ORIGINAL.value}.jpg",
+                f"{IMAGE_DIR}/{image_hash}/{ImageTypes.ORIGINAL.value}.jpg",
                 type="JPEG",
                 quality=IMAGE_QUALITY,
             )
@@ -335,8 +336,8 @@ def generate_blur_hash(image: Image) -> str:
 
 
 @db_session
-def process_image(image: Image, image_identifier: str, image_id: int) -> None:
-    console.log(f"Processing image, id={image_id}.")
+def process_image(image: Image, image_hash: str, image_id: int) -> None:
+    console.log(f"Processing image, id={image_id}. sha256sum={image_hash}")
     # all resized images get 4 different pixel ratios, returned in an array from
     # 0 to 3, where the pixel ratio is the index + 1. except for posts.
     # we always deliver them in ''full'' quality (defined by MAX_IMAGE_SIZE_POST)
@@ -364,7 +365,7 @@ def process_image(image: Image, image_identifier: str, image_id: int) -> None:
         ImageTypes.PROFILE_PICTURE_LARGE: arr_profilepic_lg,
     }
 
-    save_images_to_disk(images, image_identifier)
+    save_images_to_disk(images, image_hash)
 
     db_image = db.Image.get(id=image_id)
     db_image.processed = True
@@ -389,13 +390,28 @@ def handle_upload(
 ) -> SimpleNamespace:
     # check that the given data is valid.
     _verify_image(image)
-    image = convert_buffer_to_image(image)
-    access_id = create_random_image_identifier()
 
     uploader = db.User.get(id=userid)
     if uploader is None:
         console.log("[bold red]Could not commit to DB: user id does not exist!")
         raise InvalidImageException  # should maybe rename this?
+
+    # before we bother processing the image, we check if any image with an identical
+    # hash exists, since there is no point duplicating them in storage.
+
+    # get the hash of the image
+    image_hash = sha256(image.read()).hexdigest()
+    image.seek(0)
+
+    # and try to find an existing Image with the same one.
+    # if this != null, we'll use it to fill in some Image entry fields later.
+    existing_image = select(
+        image for image in db.Image if image.sha256sum is image_hash
+    ).limit(1)[::]
+    existing_image = existing_image[0] if len(existing_image) >= 1 else None
+
+    image = convert_buffer_to_image(image)
+    access_id = create_random_image_identifier()
 
     # create the image entry now, so we can give back an identifier.
     entry = db.Image(
@@ -403,18 +419,21 @@ def handle_upload(
         identifier=access_id,
         uploader=db.User.get(id=userid),
         blur_hash=PROCESSING_BLURHASH,
+        sha256sum=image_hash,
         processed=False,
     )
 
     commit()
 
+    if existing_image is not None:
+        entry.blur_hash = existing_image.blur_hash
+        entry.processed = True
+        return SimpleNamespace(id=entry.id, identifier=access_id, processed=True)
+
     if threaded:
-        Thread(target=lambda: process_image(image, access_id, entry.id)).start()
+        Thread(target=lambda: process_image(image, image_hash, entry.id)).start()
     else:
-        process_image(image, access_id, entry.id)
+        process_image(image, image_hash, entry.id)
 
     # if we're not using threading, then it will have been processed by now.
     return SimpleNamespace(id=entry.id, identifier=access_id, processed=(not threaded))
-
-    # entry = commit_image_to_db(access_id, userid, generate_blur_hash(image))
-    # return SimpleNamespace(id=entry, identifier=access_id)

--- a/socialserver/util/video.py
+++ b/socialserver/util/video.py
@@ -34,6 +34,9 @@ def _verify_video(video: BytesIO):
 
 def write_video(video: BytesIO, video_hash: str) -> None:
     console.log(f"Writing new video, hash={video_hash}")
+    # FIXME: testing needs work before this is removed.
+    if path.exists(f"{VIDEO_DIR}/{video_hash}"):
+        return
     mkdir(f"{VIDEO_DIR}/{video_hash}")
     with open(f"{VIDEO_DIR}/{video_hash}/video.mp4", "wb") as video_file:
         video_file.write(video.read())


### PR DESCRIPTION
Images and videos are now stored in the filesystem based on their SHA256 hash (of the uploaded file, before conversion.)

This way, if two people upload the same image, we're only storing it once. (With two Image entries pointing towards it.)
The same for videos.

The other (possibly bigger) benefit is instant processing, since we can just use the already processed one.

It's not in a perfect state, but it's functional for now.